### PR TITLE
Add Spanish documentation for Teramot MCP

### DIFF
--- a/teramot-documentation/docs/authentication.md
+++ b/teramot-documentation/docs/authentication.md
@@ -1,0 +1,96 @@
+---
+title: Authentication
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+
+# Authentication
+
+The Teramot MCP server supports two authentication modes. Both pass a Bearer token to the
+server; pick the one your client supports.
+
+| Mode | Use it for |
+| --- | --- |
+| **OAuth 2.0 + PKCE** | Claude (Code, Desktop, Browser), ChatGPT, and any client that can complete an OAuth flow |
+| **Static API key** | Cursor, v0.dev, Antigravity, and any client that only supports a static Bearer token |
+
+Both modes coexist on the same endpoint, and both grant the same access. The discovery
+methods `initialize` and `tools/list` require no token at all (see
+[Overview → Bootstrap methods](./intro.md#bootstrap-methods-no-authentication)).
+
+<Admonition type="info">
+Your connection is **account-wide**: the same credentials apply to every workspace and project
+on your Teramot account. You don't need a separate token per workspace.
+</Admonition>
+
+## OAuth 2.0 + PKCE
+
+This is the recommended path for clients that support it. You only configure two values —
+the **MCP URL** (`https://mcp.teramot.com/mcp`) and the **Client ID**
+(`5nldf3wj83yz9f6zbrsjx`). The client opens a browser window, you log in to Teramot, and the
+client receives and refreshes tokens automatically.
+
+Under the hood the server exposes the standard OAuth 2.0 metadata and endpoints, so most MCP
+clients configure themselves with no extra input:
+
+- `GET /.well-known/oauth-authorization-server` — authorization server metadata (RFC 8414)
+- `GET /.well-known/oauth-protected-resource` — protected resource metadata (RFC 9728)
+- `GET /authorize` — authorization endpoint
+- `POST /token` — token endpoint
+- `POST /register` — dynamic client registration
+
+The flow uses PKCE (`S256`) and the scopes `openid email access offline_access`. See
+**[Connecting your client](./connect-clients.md)** for per-client steps.
+
+## Static API key
+
+For clients that can't complete the OAuth handshake (Cursor, v0.dev, Antigravity), generate a
+static API key and send it as a Bearer token.
+
+### Generate a key
+
+1. Open the Teramot app and go to the **MCP** page.
+2. In the **API Keys** section, enter a name (e.g. `cursor-work`) and click **Generate Key**.
+3. **Copy the key now — it won't be shown again.**
+
+You can create multiple keys (one per client/machine) and delete any of them later from the
+same page.
+
+### Use the key
+
+Send it in the `Authorization` header:
+
+```http
+Authorization: Bearer YOUR_API_KEY
+```
+
+Most MCP clients accept a custom header in their server config:
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Admonition type="caution">
+Treat API keys like passwords. They grant full access to your account's data. If a key leaks,
+delete it from the **MCP → API Keys** page and generate a new one.
+</Admonition>
+
+## Errors
+
+| Situation | Result |
+| --- | --- |
+| No token on an authenticated method | `401 Unauthorized` |
+| Expired or invalid token | `401 Unauthorized` |
+| Missing `Mcp-Session-Id` on `GET /mcp` | `401 Unauthorized` (`missing Mcp-Session-Id; re-initialize via POST`) |

--- a/teramot-documentation/docs/connect-clients.md
+++ b/teramot-documentation/docs/connect-clients.md
@@ -1,0 +1,144 @@
+---
+title: Connecting your client
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+
+# Connecting your client
+
+Use these values to connect your MCP client to the Teramot MCP server.
+
+| | |
+| --- | --- |
+| **MCP URL** | `https://mcp.teramot.com/mcp` |
+| **Client ID** | `5nldf3wj83yz9f6zbrsjx` |
+
+<Admonition type="info">
+**Claude** and **ChatGPT** authenticate with OAuth — they only need the MCP URL (and Client ID
+if prompted). **Cursor**, **v0.dev**, and **Antigravity** use a static API key — generate one
+first on the **MCP → API Keys** page (see [Authentication](./authentication.md#static-api-key)).
+</Admonition>
+
+<Tabs>
+
+<TabItem value="claude-code" label="Claude Code">
+
+Run this command in your terminal:
+
+```bash
+claude mcp add --transport http --client-id 5nldf3wj83yz9f6zbrsjx --callback-port 8090 teramot https://mcp.teramot.com/mcp
+```
+
+A browser window opens for you to authorize with Teramot. After that, the `teramot` tools are
+available in Claude Code.
+
+</TabItem>
+
+<TabItem value="claude-desktop" label="Claude Desktop / Browser">
+
+1. Open **Settings → Developer → MCP Servers** (or **Edit Config**).
+2. Add a new server with these values:
+   - **Name:** `teramot`
+   - **Transport:** `HTTP`
+   - **URL:** `https://mcp.teramot.com/mcp`
+   - **Client ID:** `5nldf3wj83yz9f6zbrsjx` (if required)
+3. Save and restart Claude Desktop.
+4. Open a new chat and activate the **teramot** connector.
+
+</TabItem>
+
+<TabItem value="chatgpt" label="ChatGPT">
+
+In ChatGPT, open **Settings → Apps** (or **Apps & Connectors**), add a custom MCP app, and use
+these values:
+
+- **Server URL:** `https://mcp.teramot.com/mcp`
+- **Client ID:** `5nldf3wj83yz9f6zbrsjx`
+
+Step by step on ChatGPT Desktop / Browser:
+
+1. Open ChatGPT and go to **Settings**.
+2. Open **Apps** (or **Apps & Connectors**) and create/import a custom MCP app.
+3. Configure the app with these values:
+   - **Name:** `teramot`
+   - **Transport:** `HTTP`
+   - **URL:** `https://mcp.teramot.com/mcp`
+   - **Client ID:** `5nldf3wj83yz9f6zbrsjx` (if required)
+4. Save the configuration and complete authorization if prompted.
+5. Open a new chat and enable the **teramot** app.
+
+</TabItem>
+
+<TabItem value="cursor" label="Cursor">
+
+Cursor uses a **static API key**. First generate one on the **MCP → API Keys** page
+(see [Authentication](./authentication.md#static-api-key)), then add the server to your MCP
+config (Settings → MCP, or `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="v0" label="v0.dev">
+
+v0.dev uses a **static API key**. Generate one on the **MCP → API Keys** page
+(see [Authentication](./authentication.md#static-api-key)) and add the server with the
+`Authorization: Bearer` header:
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="antigravity" label="Antigravity">
+
+Antigravity uses a **static API key**. Generate one on the **MCP → API Keys** page
+(see [Authentication](./authentication.md#static-api-key)) and configure the MCP server with
+the `Authorization: Bearer` header:
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+## Verify the connection
+
+Once connected, ask your client to **list your workspaces** — it should call `list_workspaces`
+and return them. From there you can explore projects, preview tables, and build results tables.
+See the full **[Tools Reference](./tools-reference.md)**.

--- a/teramot-documentation/docs/intro.md
+++ b/teramot-documentation/docs/intro.md
@@ -1,147 +1,90 @@
 ---
-title: Teramot MCP API Documentation
-sidebar_position: 2
+title: Teramot MCP — Overview
+sidebar_position: 1
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 import Admonition from '@theme/Admonition';
 
-# Teramot MCP API Documentation
+# Teramot MCP — Overview
 
-## Overview
+The Teramot Model Context Protocol (MCP) server lets any MCP-compatible AI client
+(Claude, ChatGPT, Cursor, and others) work directly with your Teramot data platform.
+Once connected, the client can explore your workspaces, projects, and data sources,
+preview and query tables, and build new results (gold) tables — all through natural language.
 
-The Teramot Model Context Protocol (MCP) API provides AI-powered data engineering capabilities through a standardized protocol. Built on the MCP 2025-11-25 specification, it enables seamless integration with MCP-compatible clients while maintaining enterprise security and scalability.
+It implements the **Streamable HTTP** MCP transport with OAuth 2.0 (or a static token)
+for authentication.
 
-**Base URL**: `https://api.teramot.com/mcp`
+## Connection essentials
 
-## What is MCP?
+| | |
+| --- | --- |
+| **Endpoint** | `https://mcp.teramot.com/mcp` |
+| **Transport** | Streamable HTTP (`POST` for JSON-RPC, `GET` for the SSE stream) |
+| **Client ID** | `5nldf3wj83yz9f6zbrsjx` |
+| **Authentication** | OAuth 2.0 + PKCE, or a static API key (Bearer token) |
+| **Server** | `teramot-mcp` `v0.1.0` |
 
-Model Context Protocol (MCP) is an open standard that allows AI applications to securely connect to data sources and tools. Teramot's implementation provides:
-
-- ✅ **AI-Powered Data Analysis**: Natural language to SQL query generation
-- 🔐 **Enterprise Security**: JWT-based authentication with dynamic scopes
-- 📊 **Usage Tracking**: Comprehensive monitoring and billing integration
-- 🚀 **Real-time Streaming**: Server-Sent Events for long-running operations
-<!-- - 🛠️ **Table Expert Agent**: Advanced data engineering capabilities -->
-
-## Authentication
-
-### JWT Token Requirements
-
-All MCP endpoints (except `initialize` and `tools/list`) require a valid JWT token with specific scopes:
-
-**Required Scope Pattern**: `mcp:tools:your-usecase-id`
-
-**Example Scopes**:
-- `mcp:tools:sales-analysis` - Access to sales analysis data
-
-**Unauthenticated Methods** (bootstrap flow):
-- `initialize` - Always accessible without token
-- `tools/list` - Accessible without token to enable connector bootstrap
-
-**Scope Validation**:
-- Token must include `mcp:tools` base scope
-- Additional usecase-specific scope: `mcp:tools:{usecase_id}`
-- Server extracts `usecase_id` from token claims
-- All tool calls automatically receive the authenticated `usecase_id`
-
-### Headers
-
-```http
-Authorization: Bearer YOUR_JWT_TOKEN
-Accept: application/json, text/event-stream
-Content-Type: application/json
-mcp-session-id: SESSION_UUID  # Optional, for session management
-```
-
-### Authentication Flow
-
-<Admonition type="info">
-1. **No auth required**: `initialize` and `tools/list` methods (bootstrap flow)
-2. **JWT required**: All other methods (`tools/call`, `resources/list`, `resources/read`)
-3. **Dynamic scopes**: Token must include specific use case access
+<Admonition type="tip">
+Most users never touch the protocol directly — see **[Connecting your client](./connect-clients.md)**
+for copy-paste setup for Claude, ChatGPT, Cursor, v0.dev, and Antigravity. This page documents the
+underlying protocol for custom integrations.
 </Admonition>
 
-## API Endpoints
+## How connecting works
 
-### Core MCP Endpoint
+1. The client points at `https://mcp.teramot.com/mcp` and (for OAuth clients) the Client ID above.
+2. The client calls `initialize` and `tools/list` to discover capabilities — these require **no authentication**.
+3. For any real work (`tools/call`), the client authenticates with a Bearer token, obtained either via
+   the automatic OAuth flow or a static API key. See **[Authentication](./authentication.md)**.
 
-#### `POST /mcp/`
+## Transport & endpoints
 
-Main MCP endpoint handling all JSON-RPC 2.0 requests.
+All traffic goes to a single endpoint, `https://mcp.teramot.com/mcp`.
 
-**Content Types**:
-- Request: `application/json`
-- Response: `application/json` or `text/event-stream`
+### `POST /mcp`
 
-<Tabs>
-<TabItem value="request" label="Request Format">
+Carries JSON-RPC 2.0 requests (`initialize`, `tools/list`, `tools/call`, …). Responses are
+returned as `application/json` or, for streaming operations, as `text/event-stream`.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "request-id",
-  "method": "METHOD_NAME",
-  "params": { }
-}
+```http
+POST /mcp HTTP/1.1
+Host: mcp.teramot.com
+Authorization: Bearer YOUR_TOKEN
+Accept: application/json, text/event-stream
+Content-Type: application/json
+Mcp-Session-Id: SESSION_UUID   # echoed after initialize
 ```
 
-</TabItem>
-<TabItem value="response" label="Response Format">
+### `GET /mcp`
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "request-id",
-  "result": { },
-  "error": { }
-}
-```
+Opens a Server-Sent Events stream for server-to-client messages. Requires the
+`Mcp-Session-Id` header returned by `initialize`; without it the server responds
+`401 Unauthorized` (`missing Mcp-Session-Id; re-initialize via POST`).
 
-</TabItem>
-</Tabs>
+### Bootstrap methods (no authentication)
 
-#### `GET /mcp/`
+To let clients discover the server before authorizing, three methods skip auth:
 
-Opens Server-Sent Events stream for real-time server-to-client communication.
+- `initialize`
+- `tools/list`
+- `notifications/initialized`
 
-**Requirements**:
-- Header: `Accept: text/event-stream`
-- Authentication: Required (`mcp:tools` scope)
+Every other method requires a valid Bearer token.
 
-**Response**: SSE stream with connection status, ready signals, and heartbeat events.
+## Session management
 
-#### `OPTIONS /mcp/`
+`initialize` returns an `Mcp-Session-Id` response header. Include it on subsequent
+requests and on the `GET /mcp` stream. Sessions are held in memory and reset when the
+server restarts — if a session is lost, simply call `initialize` again.
 
-CORS preflight handling.
-
-#### `DELETE /mcp/`
-
-Client disconnection endpoint.
-
-#### `GET /mcp/tools/list`
-
-List available tools (GET endpoint for backward compatibility).
-
-**Authentication**: Not required (part of bootstrap flow)
-
-#### `GET /mcp/resources/list`
-
-List available resources (GET endpoint for backward compatibility).
-
-**Authentication**: Required (`mcp:tools` scope)
-
-## MCP Methods
+## MCP methods
 
 ### `initialize`
 
-Initialize MCP connection and negotiate capabilities.
-
-<Admonition type="note">
-**Authentication**: Not required
-</Admonition>
+Negotiate protocol version and capabilities. **No authentication required.**
 
 <Tabs>
 <TabItem value="request" label="Request">
@@ -152,15 +95,9 @@ Initialize MCP connection and negotiate capabilities.
   "id": "init-1",
   "method": "initialize",
   "params": {
-    "protocolVersion": "2025-11-25",
-    "capabilities": {
-      "tools": {},
-      "resources": {}
-    },
-    "clientInfo": {
-      "name": "MyApp",
-      "version": "1.0.0"
-    }
+    "protocolVersion": "2024-11-05",
+    "capabilities": { "tools": {} },
+    "clientInfo": { "name": "MyApp", "version": "1.0.0" }
   }
 }
 ```
@@ -173,17 +110,10 @@ Initialize MCP connection and negotiate capabilities.
   "jsonrpc": "2.0",
   "id": "init-1",
   "result": {
-    "protocolVersion": "2025-11-25",
-    "capabilities": {
-      "tools": {"listChanged": true},
-      "resources": {"listChanged": true, "subscribe": true},
-      "logging": {}
-    },
-    "serverInfo": {
-      "name": "Teramot MCP Server",
-      "version": "1.0.0"
-    },
-    "instructions": "Teramot MCP Server - AI-powered data engineering capabilities"
+    "protocolVersion": "2024-11-05",
+    "capabilities": { "tools": { "listChanged": true } },
+    "serverInfo": { "name": "teramot-mcp", "version": "v0.1.0" },
+    "instructions": "You are connected to the Teramot data platform. Help users explore their workspaces, projects, data sources, tables, and create results tables."
   }
 }
 ```
@@ -191,15 +121,12 @@ Initialize MCP connection and negotiate capabilities.
 </TabItem>
 </Tabs>
 
-**Session Management**: Response includes `mcp-session-id` header for subsequent requests.
+The response carries the `Mcp-Session-Id` header for subsequent requests.
 
 ### `tools/list`
 
-List available MCP tools.
-
-<Admonition type="note">
-**Authentication**: Not required (part of bootstrap flow)
-</Admonition>
+List the available tools. **No authentication required** (part of the bootstrap flow).
+See the full catalog in **[Tools Reference](./tools-reference.md)**.
 
 <Tabs>
 <TabItem value="request" label="Request">
@@ -222,103 +149,19 @@ List available MCP tools.
   "result": {
     "tools": [
       {
-        "name": "list_gold_tables",
-        "description": "List all GOLD (analytical) tables in the data warehouse.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "usecase_id": {
-              "type": "string",
-              "description": "Optional usecase identifier. If not provided, uses the usecase from your token."
-            }
-          }
-        }
+        "name": "list_workspaces",
+        "description": "Lists all workspaces the user has access to.",
+        "inputSchema": { "type": "object", "properties": {} }
       },
       {
-        "name": "list_silver_tables",
-        "description": "List all SILVER (processed) tables in the data warehouse.",
+        "name": "preview_table",
+        "description": "Preview the first 100 rows of a data table.",
         "inputSchema": {
           "type": "object",
           "properties": {
-            "usecase_id": {
-              "type": "string",
-              "description": "Optional usecase identifier. If not provided, uses the usecase from your token."
-            }
-          }
-        }
-      },
-      {
-        "name": "peek",
-        "description": "Preview a table by showing its structure and sample rows.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "table_name": {
-              "type": "string",
-              "description": "Name of the table to preview"
-            },
-            "limit": {
-              "type": "integer",
-              "description": "Number of rows to preview (default: 5, max: 20)"
-            },
-            "usecase_id": {
-              "type": "string",
-              "description": "Optional usecase identifier"
-            }
+            "table_name": { "type": "string", "description": "Name of the table to preview" }
           },
           "required": ["table_name"]
-        }
-      },
-      {
-        "name": "validate_gold_request",
-        "description": "Validates a create_gold_table request.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "Proposed name for the gold table"
-            },
-            "description": {
-              "type": "string",
-              "description": "Description of the table content"
-            },
-            "source_tables": {
-              "type": "string",
-              "description": "Comma-separated list of silver table names"
-            },
-            "questions": {
-              "type": "string",
-              "description": "Explicit SQL instructions derived from the user's request"
-            }
-          },
-          "required": ["name", "description"]
-        }
-      },
-      {
-        "name": "create_gold_table",
-        "description": "Create a new gold table using AI to generate SQL.",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "Name for the new table"
-            },
-            "description": {
-              "type": "string",
-              "description": "What the table should contain"
-            },
-            "questions": {
-              "type": "string",
-              "description": "Explicit SQL instructions that drive the generated query"
-            },
-            "source_tables": {
-              "type": "string",
-              "description": "Comma-separated list of silver table names to use"
-            }
-          },
-          "required": ["name", "description"]
         }
       }
     ]
@@ -331,11 +174,7 @@ List available MCP tools.
 
 ### `tools/call`
 
-Execute a specific tool.
-
-<Admonition type="warning">
-**Authentication**: Required (`mcp:tools` scope)
-</Admonition>
+Execute a tool. **Authentication required** (Bearer token).
 
 <Tabs>
 <TabItem value="request" label="Request">
@@ -346,11 +185,8 @@ Execute a specific tool.
   "id": "call-tool",
   "method": "tools/call",
   "params": {
-    "name": "peek",
-    "arguments": {
-      "table_name": "ventas_mensuales",
-      "limit": 3
-    }
+    "name": "preview_table",
+    "arguments": { "table_name": "sales" }
   }
 }
 ```
@@ -364,10 +200,7 @@ Execute a specific tool.
   "id": "call-tool",
   "result": {
     "content": [
-      {
-        "type": "text",
-        "text": "{\n  \"table_name\": \"ventas_mensuales\",\n  \"layer\": \"gold\",\n  \"usecase_id\": \"sales-analysis\",\n  \"columns\": [\n    {\"name\": \"mes\", \"type\": \"varchar\"},\n    {\"name\": \"total_ventas\", \"type\": \"decimal\"},\n    {\"name\": \"numero_pedidos\", \"type\": \"bigint\"},\n    {\"name\": \"ticket_promedio\", \"type\": \"decimal\"}\n  ],\n  \"preview\": [\n    {\"mes\": \"2024-01\", \"total_ventas\": 145230.50, \"numero_pedidos\": 342, \"ticket_promedio\": 424.68},\n    {\"mes\": \"2024-02\", \"total_ventas\": 158940.75, \"numero_pedidos\": 389, \"ticket_promedio\": 408.59},\n    {\"mes\": \"2024-03\", \"total_ventas\": 172815.20, \"numero_pedidos\": 401, \"ticket_promedio\": 431.04}\n  ],\n  \"total_rows\": 12,\n  \"retrieved_at\": \"2024-04-15T14:22:00Z\"\n}"
-      }
+      { "type": "text", "text": "{ \"columns\": [...], \"rows\": [...] }" }
     ]
   }
 }
@@ -376,589 +209,30 @@ Execute a specific tool.
 </TabItem>
 </Tabs>
 
-<!-- **Features**:
-- Automatic `usecase_id` injection from JWT token
-- Usage tracking and billing integration
-- SQL query generation and execution
-- Performance monitoring
-- Plot generation (when applicable) -->
+## Error handling
 
-<!--
-### `resources/list`
-
-List available MCP resources.
-
-<Admonition type="warning">
-**Authentication**: Required (`mcp:tools` scope)
-</Admonition>
-
-<Tabs>
-<TabItem value="request" label="Request">
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "list-resources",
-  "method": "resources/list"
-}
-```
-
-</TabItem>
-<TabItem value="response" label="Response">
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "list-resources", 
-  "result": {
-    "resources": [
-      {
-        "uri": "teramot://table-expert/capabilities",
-        "name": "Table Expert Capabilities",
-        "description": "Documentation about Table Expert tool capabilities and usage"
-      }
-    ]
-  }
-}
-```
-
-</TabItem>
-</Tabs>
-
-### `resources/read`
-
-Read a specific resource.
-
-<Admonition type="warning">
-**Authentication**: Required (`mcp:tools` scope)
-</Admonition>
-
-<Tabs>
-<TabItem value="request" label="Request">
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "read-resource",
-  "method": "resources/read",
-  "params": {
-    "uri": "teramot://table-expert/capabilities"
-  }
-}
-```
-
-</TabItem>
-<TabItem value="response" label="Response">
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "read-resource",
-  "result": {
-    "contents": [
-      {
-        "uri": "teramot://table-expert/capabilities",
-        "text": "# Table Expert Capabilities\n\nThe Table Expert provides:\n- SQL Query Generation\n- Data Analysis\n- Visualization\n- Performance Monitoring..."
-      }
-    ]
-  }
-}
-```
-
-</TabItem>
-</Tabs>
--->
-
-## Available Tools
-
-### Data Warehouse Query Tools
-
-#### `list_gold_tables`
-
-List all GOLD (analytical) tables in the data warehouse.
-
-**Parameters**:
-- `usecase_id` (string, optional): Usecase identifier. If not provided, uses the usecase from your token.
-
-**Returns**:
-- Table names and IDs
-- Column schemas with data types
-- Table status (ready, processing, error)
-- Row counts and metadata
-
-#### `list_silver_tables`
-
-List all SILVER (processed) tables in the data warehouse.
-
-**Parameters**:
-- `usecase_id` (string, optional): Usecase identifier
-
-**Returns**:
-- Table names, columns, and data types
-- Foreign key relationships
-- Processing status and metadata
-
-**Note**: SILVER tables are automatically created when data sources are connected and represent cleaned, processed data.
-
-#### `peek`
-
-Preview a table by showing its structure and sample rows.
-
-**Parameters**:
-- `table_name` (string, required): Name of the table to preview
-- `limit` (integer, optional): Number of rows to return (default: 5)
-- `usecase_id` (string, optional): Usecase identifier
-
-**Works With**: Both SILVER and GOLD tables
-
-**Returns**:
-- Column names and data types
-- Sample rows (up to specified limit)
-- Total row count
-
-**Example Workflow**:
-1. Call `list_silver_tables()` to see available tables
-2. Call `peek('tablename')` to preview its data
-
-#### `get_gold_sql`
-
-Get the SQL query definition for a gold table.
-
-**Parameters**:
-- `table_name` (string, required): Name of the gold table
-- `usecase_id` (string, optional): Usecase identifier
-
-**Returns**:
-- Complete SQL SELECT statement
-- All filters, joins, and transformations
-- Table status and columns
-- Creation metadata
-
-#### `get_table_relationships`
-
-Get foreign key relationships between silver tables.
-
-**Parameters**:
-- `usecase_id` (string, optional): Usecase identifier
-
-**Returns**:
-- Foreign key mappings
-- Referenced tables and columns
-- Relationship types
-
-**Use Case**: Helps choose related tables when creating gold tables.
-
----
-
-### Table Management Tools
-
-#### `validate_gold_request`
-
-Validates a create_gold_table request.
-
-**Parameters**:
-- `name` (string, required): Proposed name for the gold table
-- `description` (string, required): Description of the table content
-- `source_tables` (string, optional): Comma-separated list of silver table names
-- `questions` (string, optional): Explicit SQL instructions derived from the user's request
-
-**Required Workflow**:
-Must be called and results shown to the user BEFORE calling `create_gold_table`.
-
-#### `create_gold_table`
-
-Create a new gold table using AI to generate SQL.
-
-**Parameters**:
-- `name` (string, required): Name for the new gold table
-- `description` (string, required): What the table should contain
-- `questions` (string, optional): Explicit SQL instructions that drive the generated query
-- `source_tables` (string, optional): Comma-separated silver table names to use
-
-**Required Workflow**:
-1. Call `list_silver_tables()` to see available data
-2. Call `get_table_relationships()` to see how tables connect
-3. Call `validate_gold_request()` → show results to user
-   - high certainty → proceed to step 4
-   - low certainty → ask user, then re-validate
-4. Call `create_gold_table()` with selected source tables
-
-**Implementation**: Triggers async Celery task in auto-etl for SQL generation and table creation.
-
-#### `get_table_status`
-
-Get detailed status of a specific table.
-
-**Parameters**:
-- `table_name` (string, required): Name of the table
-- `usecase_id` (string, optional): Usecase identifier
-
-**Returns**:
-- Table metadata and columns
-- Processing status
-- Preview data
-- Error information (if any)
-
----
-
-### Project/Usecase Tools
-
-**Note**: These tools are currently not active in the implementation.
-
-#### `list_projects`
-
-List all available projects/usecases.
-
-**Returns**:
-- Project IDs and names
-- Status information
-- Creation metadata
-
-#### `get_project`
-
-Get detailed information about a specific project.
-
-**Parameters**:
-- `usecase_id` (string, required): Usecase identifier
-
-**Returns**:
-- Complete project details
-- Associated tables and sources
-- Configuration and status -->
-
-
-<!-- ---
-
-### Table Expert Agent Tools
-
-#### `call_table_expert_a2a`
-
-Invoke the Table Expert Agent via A2A (Agent-to-Agent) protocol.
-
-**Parameters**:
-- `message` (string, required): Natural language question or analysis request
-- `topic` (string, optional): Topic or domain for analysis
-- `usecase_id` (string, optional): Usecase identifier
-
-**Capabilities**:
-- **SQL Generation**: Natural language to optimized SQL queries
-- **Data Analysis**: Statistical analysis and insights
-- **Visualization**: Automatic plot generation for visual data
-- **Performance Tracking**: Execution time monitoring
-
-**Example Use Cases**:
-
-<Tabs>
-<TabItem value="sales" label="Sales Analysis">
-
-```json
-{
-  "message": "Show monthly revenue trends for the last 12 months",
-  "topic": "revenue-analysis"
-}
-```
-
-</TabItem>
-<TabItem value="customer" label="Customer Segmentation">
-
-```json
-{
-  "message": "Segment customers by purchase frequency and lifetime value",
-  "topic": "customer-analytics"
-}
-```
-
-</TabItem>
-<TabItem value="product" label="Product Performance">
-
-```json
-{
-  "message": "Which products have the highest profit margins?",
-  "topic": "product-analysis"
-}
-```
-
-</TabItem>
-</Tabs>
-
-**Response Format**:
-- Formatted analysis with insights
-- Generated SQL queries (when applicable)
-- Execution time and performance metrics
-- Plot URLs for visualizations
-- Metadata about the analysis process -->
-
----
-
-<!--
-### Core Integration Tools
-
-#### `search`
-
-ChatGPT-required search tool. Returns summarized insights for a query.
-
-**Parameters**:
-- `query` (string, required): Search query
-- `limit` (int, optional): Number of results
-
----
-
-#### `fetch`
-
-ChatGPT-required fetch tool. Returns a specific resource by identifier.
-
-**Parameters**:
-- `resource_id` (string, required): Resource to fetch
-
----
-
-#### `schema`
-
-Return a minimal schema description for the current usecase.
-
----
-
-#### `explain`
-
-Provide a short explanation for a resource or query identifier.
-
-**Parameters**:
-- `id` (string, required): Identifier to explain
--->
-
-
-## Session Management
-
-### Session Lifecycle
-
-1. **Initialize**: Call `initialize` method to optionally create a session
-2. **Session ID**: Server returns `mcp-session-id` header if session is created
-3. **Subsequent Requests**: Optionally include session ID in requests
-4. **Validation**: Server validates session only if `mcp-session-id` header is provided
-
-### Session Headers
-
-```http
-mcp-session-id: 550e8400-e29b-41d4-a716-446655440000
-```
-
-### Session Behavior
-
-- Sessions are **optional** for the current implementation
-- If provided, the session will be validated
-- `initialize` method can create a session, but it's not mandatory
-- Session validation only occurs when `mcp-session-id` header is present
-
-## Error Handling
-
-### HTTP Status Codes
-
-| Status Code | Description |
-|------------|-------------|
-| `200 OK` | Successful request |
-| `400 Bad Request` | Invalid JSON or malformed request |
-| `401 Unauthorized` | Missing or invalid authentication |
-| `403 Forbidden` | Insufficient scope permissions |
-| `404 Not Found` | Session not found or invalid endpoint |
-| `500 Internal Server Error` | Server-side processing error |
-
-### JSON-RPC Error Codes
+Standard JSON-RPC 2.0 error codes apply:
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": "request-id",
-  "error": {
-    "code": -32000,
-    "message": "Error description"
-  }
+  "error": { "code": -32602, "message": "Invalid params" }
 }
 ```
 
-**Common Error Codes**:
-- `-32700`: Parse error (invalid JSON)
-- `-32600`: Invalid request (malformed JSON-RPC)
-- `-32601`: Method not found
-- `-32602`: Invalid params
-- `-32000`: Internal error
+| Code | Meaning |
+| --- | --- |
+| `-32700` | Parse error (invalid JSON) |
+| `-32600` | Invalid request (malformed JSON-RPC) |
+| `-32601` | Method not found |
+| `-32602` | Invalid params |
+| `-32000` | Internal / authentication error |
 
-### Authentication Errors
+At the HTTP layer, a missing or expired token returns `401 Unauthorized`.
 
-<Tabs>
-<TabItem value="missing" label="Missing Authentication">
+## Next steps
 
-```json
-{
-  "error": {
-    "code": -32000,
-    "message": "Authentication required"
-  }
-}
-```
-
-</TabItem>
-<TabItem value="scope" label="Insufficient Scope">
-
-```json
-{
-  "error": {
-    "code": -32000, 
-    "message": "Insufficient scope: requires mcp:tools:your-usecase-id"
-  }
-}
-```
-
-</TabItem>
-<TabItem value="session" label="Session Not Found">
-
-```json
-{
-  "error": {
-    "code": -32000,
-    "message": "Session not found"
-  }
-}
-```
-
-</TabItem>
-</Tabs>
-
-## Batch Requests
-
-MCP supports JSON-RPC batch requests for multiple operations:
-
-<Tabs>
-<TabItem value="batch-request" label="Request">
-
-```json
-[
-  {
-    "jsonrpc": "2.0",
-    "id": "1",
-    "method": "tools/list"
-  },
-  {
-    "jsonrpc": "2.0", 
-    "id": "2",
-    "method": "resources/list"
-  }
-]
-```
-
-</TabItem>
-<TabItem value="batch-response" label="Response">
-
-```json
-[
-  {
-    "jsonrpc": "2.0",
-    "id": "1",
-    "result": {"tools": [...]}
-  },
-  {
-    "jsonrpc": "2.0",
-    "id": "2", 
-    "result": {"resources": [...]}
-  }
-]
-```
-
-</TabItem>
-</Tabs>
-
-<Admonition type="caution" title="Batch Limitations">
-- `initialize` method cannot be part of batch requests
-- Methods `initialize` and `tools/list` do not require authentication
-- All other methods in batch must have valid authentication (JWT with `mcp:tools` scope)
-- Batch processing is not strictly atomic - each request is processed independently
-</Admonition>
-
-## Streaming Responses
-
-### Server-Sent Events (SSE)
-
-For real-time updates and long-running operations:
-
-**Request Headers**:
-```http
-Accept: text/event-stream
-```
-
-**Response Format**:
-```
-id: event-12345
-event: message
-data: {"jsonrpc": "2.0", "id": "request-id", "result": {...}}
-
-```
-
-**Event Types**:
-- `connection`: Connection established
-- `ready`: Server ready for requests
-- `ping`: Heartbeat events (every 30 seconds)
-- `message`: Actual response data
-- `error`: Error events
-
-### Streaming Use Cases
-
-- Long-running data analysis queries
-- Real-time progress updates
-- Large result set processing
-- Connection keep-alive
-
-## Usage Tracking
-
-All tool executions are automatically tracked for:
-
-### Billing Integration
-- Cost allocation per use case
-- Resource consumption monitoring
-- Usage pattern analysis
-
-### Performance Monitoring  
-- Execution time tracking
-- Success/failure rates
-- Query optimization insights
-
-### Audit Trails
-- Complete request/response logging
-- User activity tracking
-- Security event monitoring
-
-## Rate Limiting
-
-- Authentication required for all methods except `initialize` and `tools/list`
-- Usage tracked per use case and user
-- Enterprise customers: Higher rate limits available
-- Streaming connections: Independent rate limiting
-
-## Security Features
-
-### Token Validation
-- JWT signature verification
-- Scope-based authorization
-- Use case isolation
-- Token expiration handling
-
-### Data Access Control
-- Use case-specific data access
-- Dynamic scope validation
-- Secure data processing pipeline
-- Audit logging
-
-### Transport Security
-- HTTPS required for all requests
-- Secure WebSocket connections for streaming
-- CORS protection
-- Request/response logging
-
-## Support
-
-For technical support:
-- **API Issues**: Include request ID for faster resolution
-- **Authentication**: Contact your Teramot administrator
-- **Enterprise Support**: Priority support available
-
----
-
-**Specification Compliance**: This implementation follows the MCP 2025-11-25 specification with enterprise security enhancements.
+- **[Authentication](./authentication.md)** — OAuth 2.0 and static API keys.
+- **[Connecting your client](./connect-clients.md)** — Claude, ChatGPT, Cursor, v0.dev, Antigravity.
+- **[Tools Reference](./tools-reference.md)** — the full catalog of available tools.

--- a/teramot-documentation/docs/tools-reference.md
+++ b/teramot-documentation/docs/tools-reference.md
@@ -1,0 +1,170 @@
+---
+title: Tools Reference
+sidebar_position: 4
+---
+
+# Tools Reference
+
+The complete catalog of tools exposed by the Teramot MCP server, grouped by domain.
+Discover them at runtime with `tools/list`; invoke them with `tools/call`
+(see the [Overview](./intro.md#mcp-methods)).
+
+Most tools accept optional `workspace_name` and `project_name` arguments. When omitted, the
+server uses your active context (or the only workspace/project available). If you have multiple
+workspaces, name the one you mean.
+
+## Workspaces
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_workspaces` | Lists all workspaces the user has access to. Use this first to find the workspace name before listing projects. | — |
+| `create_workspace` | Create a new workspace — the top-level container you must create before projects or data sources. | `name` (string, required); `index_color` (int); `index_icon` (int) |
+| `update_workspace` | Update an existing workspace's name or appearance. | `workspace_name` (string, required); `name` (string); `index_color` (int); `index_icon` (int) |
+| `delete_workspace` | Permanently delete a workspace by name. Irreversible; requires owner access. | `workspace_name` (string, required) |
+| `get_workspace_owner` | Return the owner (member with role `owner`) of a workspace. | `workspace_name` (string) |
+| `get_workspace_members_idp_subs` | Return the IDP subjects (`idp_sub`) of every workspace member. Useful when wiring data-egress users. | `workspace_name` (string) |
+| `get_workspace_subscription` | Return the active billing subscription for a workspace, or null for free-tier. | `workspace_name` (string) |
+
+## Projects
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_projects` | Lists all projects, optionally filtered by workspace. | `workspace_name` (string) |
+| `create_project` | Create a new project inside a workspace. | `workspace_name` (string, required); `slug` (string, required, 1–28 URL-safe chars); `region` (string, required); `status` (string, required: active \| inactive \| pending) |
+| `update_project` | Update a project's name, slug, region, or status. | `project_name` (string, required); `workspace_name` (string); `name` (string); `slug` (string); `region` (string); `status` (string) |
+| `delete_project` | Permanently delete a project by name. Irreversible; requires owner access. | `project_name` (string, required); `workspace_name` (string) |
+
+## Sources & ingestion
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_sources` | Lists all ETL data sources in a project. | `workspace_name` (string); `project_name` (string) |
+| `create_etl_source` | Create an ETL data source connecting to an existing database or storage. The referenced secret must already exist. | `name` (string, required); `secret_name` (string, required); `engine` (string, required: postgresql \| mysql \| s3 \| bigquery); `slug` (string); `kind` (string); `tables_descriptions` (array); `workspace_name`/`project_name` (string) |
+| `get_etl_source` | Retrieve details of a single ETL source (status, engine, config key, discovered tables). | `source_id` or `source_name` (string); `workspace_name`/`project_name` (string) |
+| `delete_etl_source` | Delete an ETL source permanently. The associated secret is not deleted. | `source_id` or `source_name` (string, one required); `workspace_name`/`project_name` (string) |
+| `discover_schema` | Connect to the source and fetch its available tables. Call after `create_etl_source`. | `source_id` or `source_name` (string); `workspace_name`/`project_name` (string) |
+| `update_etl_source_tables` | Select which tables to ingest (and optional descriptions). Then call `publish_source` + `wait_for_publish_completion`. | `tables_descriptions` (array, required); `source_id`/`source_name` (string); `workspace_name`/`project_name` (string) |
+| `publish_source` | Publish an ETL source, triggering the async ingestion/processing pipeline. | `source_id` or `source_name` (string); `workspace_name`/`project_name` (string) |
+| `get_etl_source_status` | One-shot lifecycle status of an ETL source (created, disconnected, published, …). | `source_id` or `source_name` (string); `workspace_name`/`project_name` (string) |
+| `test_connection` | Test a source connection by creating a temporary source and running discovery. Cleans up on failure unless `keep_on_failure`. | `name` (string, required); `engine` (string, required); connection fields (`host`, `port`, `database`, `schema`, `user`, `password`, `path`, `bq_project_id`, `dataset`, `credentials_json`); `keep_on_failure` (bool); `workspace_name`/`project_name` (string) |
+| `wait_for_publish_completion` | Poll the publish pipeline. When `completed` is false, call again with the returned `follow_up_arguments`. | `source_id` or `source_name` (string); `timeout_seconds` (int); `workspace_name`/`project_name` (string) |
+
+## Secrets
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_secrets` | Lists all secret keys in a project (keys and versions only — values are never returned). | `workspace_name` (string); `project_name` (string) |
+| `create_secret` | Create or update a secret storing database/S3/BigQuery credentials. Convention: key `source_<slug>_config`. | `key` (string, required); `engine` (string, required: postgresql \| mysql \| s3 \| bigquery); engine-specific fields (`host`, `port`, `database`, `schema`, `user`, `password`, `path`, `bq_project_id`, `dataset`, `credentials_json`); `workspace_name`/`project_name` (string) |
+
+## Files & filesystem
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `prepare_file_upload` | Generate presigned S3 PUT URLs for direct upload (`.csv`, `.xls`, `.xlsx`, `.parquet`; up to 20 files; URLs expire in 30 min). | `file_names` (array, required); `parent_path` (string); `workspace_name`/`project_name` (string) |
+| `create_source_from_upload` | Finalize an upload batch by registering the files as an S3 ETL source. Does not auto-publish. | `uploaded_files` (array of `{name, key, s3_uri}`, required); `source_name` (string); `mode` (string: concat \| independent); `workspace_name`/`project_name` (string) |
+| `list_uploaded_files` | List files previously uploaded to the project's S3 bucket. | `workspace_name` (string); `project_name` (string) |
+| `delete_uploaded_files` | Permanently delete one or more uploaded files. Does not delete ETL sources that reference them. | `file_names` (array, required); `workspace_name`/`project_name` (string) |
+| `download_uploaded_file` | Build an authenticated download URL for an uploaded file (requires the caller's bearer token). | `file_name` (string, required); `workspace_name`/`project_name` (string) |
+| `list_fs_nodes` | List the project's file tree (files and folders) as a hierarchy. | `parent_id` (string); `workspace_name`/`project_name` (string) |
+| `create_folder` | Create a folder in the project's file system. | `name` (string, required); `parent_path` (string); `workspace_name`/`project_name` (string) |
+| `rename_node` | Rename a file or folder (stays under the same parent — use `move_node` to relocate). | `path` (string, required); `new_name` (string, required); `workspace_name`/`project_name` (string) |
+| `rename_uploaded_file` | Alias of `rename_node`, scoped to user-uploaded files. | `path` (string, required); `new_name` (string, required); `workspace_name`/`project_name` (string) |
+| `move_node` | Move a file or folder under a different parent. | `path` (string, required); `new_parent_path` (string, required); `workspace_name`/`project_name` (string) |
+| `move_uploaded_file` | Alias of `move_node`, scoped to user-uploaded files. | `path` (string, required); `new_parent_path` (string, required); `workspace_name`/`project_name` (string) |
+| `delete_node` | Delete a file or folder (folders delete all descendants). Irreversible. | `path` (string, required); `workspace_name`/`project_name` (string) |
+
+## Tables & data
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_available_tables` | List tables in the data warehouse. Filter by `layer`; include columns with `with_columns`. | `with_columns` (bool); `layer` (string: gold \| silver \| bronze); `workspace_name`/`project_name` (string) |
+| `get_sources` | List all ETL data sources configured for the current project. | `workspace_name` (string); `project_name` (string) |
+| `preview_table` | Preview the first 100 rows of a table (columns, types, sample rows). Accepts physical or logical name. | `table_name` (string, required); `workspace_name`/`project_name` (string) |
+| `query_data` | Execute a SQL query (TRINO dialect) against a table; returns JSON. Supports pagination via `execution_id` + `page`. | `table_name` (string, required); `sql` (string, required unless `execution_id` set); `execution_id` (string); `page` (int); `workspace_name`/`project_name` (string) |
+| `get_sql_definition` | Retrieve the SQL `SELECT` behind a results table (analysis spec). | `table_name` (string, required); `workspace_name`/`project_name` (string) |
+| `get_table_code` | Return the generated SQL that produces a source or processed table. | `table_name` (string, required); `workspace_name`/`project_name` (string) |
+| `get_artifacts` | List source tables (artifacts) for the project, with descriptions and columns. Mandatory first step before `create_gold_table`. | `workspace_name` (string); `project_name` (string) |
+| `profile_table` | Profile a table: total rows, null %, unique counts, frequent values. Operates on the JWT-bound project. | `table_name` (string, required) |
+
+## Results (gold) tables
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `validate_gold_request` | Validate a results-table request before creation (name, source tables, join-key null %, …). | `name` (string, required); `description` (string); `source_tables` (string); `questions` (string); `join_keys` (string); `workspace_name`/`project_name` (string) |
+| `create_gold_table` | Create a results table (analysis spec); generates SQL from source tables + questions. Call `get_artifacts` first. | `source_tables` (string, required, JSON array from `get_artifacts`); `name` (string); `description` (string); `questions` (string); `knowledges` (string); `workspace_name`/`project_name` (string) |
+| `list_analysis_specs` | List all results tables (analysis specs) in the current project. | `workspace_name` (string); `project_name` (string) |
+| `update_gold_table` | Update the description of a results table (only the description is mutable today). | `analysis_spec_name` (string, required); `description` (string, required); `workspace_name`/`project_name` (string) |
+| `delete_gold_table` | Permanently delete a results table and all its data. Two-step: call with `confirmed=false`, show the message, then `confirmed=true`. | `analysis_spec_name` (string); `confirmed` (bool); `workspace_name`/`project_name` (string) |
+| `duplicate_gold_table` | Duplicate a results table into a new draft analysis spec. | `analysis_spec_name` (string, required); `workspace_name`/`project_name` (string) |
+| `regenerate_gold_table_query` | Regenerate the SQL backing a results table (e.g. after editing instructions or sources). | `analysis_spec_name` (string, required); `workspace_name`/`project_name` (string) |
+| `get_gold_table_lineage` | Return the lineage graph of a results table by slug (source dependencies and derived analyses). | `slug` (string, required); `workspace_name`/`project_name` (string) |
+| `create_gold_table_instructions` | Append free-form instructions to a results table; triggers one regeneration. | `analysis_spec_name` (string, required); `instructions` (array of `{text, id?}`, required); `workspace_name`/`project_name` (string) |
+| `update_gold_table_instructions` | Update existing instructions (each item must include its id); triggers one regeneration. | `analysis_spec_name` (string, required); `instructions` (array of `{text, id}`, required); `workspace_name`/`project_name` (string) |
+| `replace_gold_table_instructions` | Replace the full instruction set; triggers one regeneration. | `analysis_spec_name` (string, required); `instructions` (array of `{text, id?}`, required); `workspace_name`/`project_name` (string) |
+| `delete_gold_table_instructions` | Remove specific instructions by ID; triggers one regeneration. | `analysis_spec_name` (string, required); `instruction_ids` (array, required); `workspace_name`/`project_name` (string) |
+
+## Status & monitoring
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `get_table_status` | Detailed status of a table (gold or silver), including processing/pipeline status. | `table_name` (string, required); `include_progress` (bool); `workspace_name`/`project_name` (string) |
+| `get_gold_table_progress` | Progress events for an in-progress (or recent) results-table creation. | `table_name` (string, required); `limit` (int); `workspace_name`/`project_name` (string) |
+
+## Refresh & scheduling
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `refresh_gold_table` | Partial refresh of a single results table to pick up new source data (produces a new revision). | `table_name` (string, required); `workspace_name`/`project_name` (string) |
+| `refresh_all_tables` | Full ETL refresh for the entire project (produces a new revision of each table). | `workspace_name` (string); `project_name` (string) |
+| `get_refresh_schedule` | List the one-shot full-refresh schedules for a project. | `workspace_name` (string); `project_name` (string) |
+| `schedule_full_refresh_at` | Schedule a one-shot full refresh at a specific UTC time (RFC3339). | `scheduled_at` (string, required, RFC3339); `workspace_name`/`project_name` (string) |
+| `delete_refresh_schedule` | Delete a one-shot full-refresh schedule by name. | `name` (string, required); `workspace_name`/`project_name` (string) |
+| `get_cron_refresh_schedule` | Get the recurring (cron) refresh schedule for the project, if any. | `workspace_name` (string); `project_name` (string) |
+| `set_cron_refresh_schedule` | Create or update the recurring refresh schedule. | `frequency` (string, required: daily \| weekly \| monthly \| hourly); `time` (string, required, HH:MM); `timezone` (string); `interval_hours` (int, required for hourly); `enabled` (bool); `workspace_name`/`project_name` (string) |
+| `delete_cron_refresh_schedule` | Remove the recurring cron refresh schedule (idempotent). | `workspace_name` (string); `project_name` (string) |
+
+## ETL tasks
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_etl_task_chains` | List ETL task chains (end-to-end pipelines) for the project. | `status` (string); `usecase_id` (string); `correlation_id` (string); `limit` (int); `cursor` (string); `workspace_name`/`project_name` (string) |
+| `list_etl_tasks` | List ETL tasks (individual steps inside a chain). | `chain_id` (string); `status` (string); `task_id` (string); `usecase_id` (string); `correlation_id` (string); `limit` (int); `cursor` (string); `workspace_name`/`project_name` (string) |
+
+## Data egress & sharing
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `get_data_egress_options` | Returns the data-egress auth options configured for a project. Read-only. | `workspace_name` (string); `project_name` (string) |
+| `create_egress_user` | Create/update a user in AWS Identity Store and assign them to the project's Lake Formation application. | `idp_sub` (string, required); `workspace_name`/`project_name` (string) |
+| `grant_table_access` | Grant a Lake Formation user read access to one or more tables. | `user_id` (string, required); `tables` (array, required); `workspace_name`/`project_name` (string) |
+| `revoke_table_access` | Revoke a single Lake Formation table from a user. | `user_id` (string, required); `table_name` (string, required); `workspace_name`/`project_name` (string) |
+| `revoke_database_access` | Revoke all database-level Lake Formation access for a user (sweeps all tables). | `user_id` (string, required); `workspace_name`/`project_name` (string) |
+| `delete_egress_user` | Delete a user from AWS Identity Store and remove their egress grants. | `user_id` (string, required); `workspace_name`/`project_name` (string) |
+| `get_user_tables` | List the Lake Formation tables a user can access (paginated via `next_token`). | `user_id` (string, required); `next_token` (string); `workspace_name`/`project_name` (string) |
+| `list_data_shares` | List the data shares originating from the current project. | `workspace_name` (string); `project_name` (string) |
+| `create_data_share` | Share data with another (consumer) project, optionally time-bound. | `consumer_project_id` (string, required); `shared_resources` (array); `expires_at` (string); `workspace_name`/`project_name` (string) |
+| `update_data_share` | Update a data share (only `expires_at` is mutable today). | `data_share_id` (string, required); `expires_at` (string); `clear_expires_at` (bool); `workspace_name`/`project_name` (string) |
+| `delete_data_share` | Permanently delete a data share (consumer loses access immediately). | `data_share_id` (string, required); `workspace_name`/`project_name` (string) |
+
+## Workspace members
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `list_workspace_members` | List all members of a workspace. Requires admin role. | `workspace_name` (string, required) |
+| `get_workspace_member_role` | Get a member's role (`owner`, `admin`, `member`, `read-only`). | `workspace_name` (string, required); `user_id` (string, required) |
+| `add_workspace_member` | Add a user by email (adds directly if they exist, else invites). Requires admin role. | `workspace_name` (string, required); `email` (string, required) |
+| `update_workspace_member_role` | Update a member's role. Requires admin role. | `workspace_name` (string, required); `user_id` (string, required); `role` (string, required) |
+| `remove_workspace_member` | Remove a member from a workspace. Requires admin role. | `workspace_name` (string, required); `user_id` (string, required) |
+| `list_workspace_invitations` | List pending invitations for a workspace. Requires admin role. | `workspace_name` (string, required) |
+
+## Chat
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `chat` | Send a chat message; AI understands intent and queries workspaces, projects, sources, and tables. Conversation scope is immutable once set. | `message` (string, required); `conversation_id` (string); `workspace_id` (string); `project_id` (string) |
+
+## Memory
+
+| Tool | Description | Parameters |
+| --- | --- | --- |
+| `memory` | Manage persistent agent memory files (view, create, str_replace, insert, delete, rename). | `command` (string, required: view \| create \| str_replace \| insert \| delete \| rename); `path` (string); `old_path` (string); `new_path` (string); `file_text` (string); `old_str` (string); `new_str` (string); `insert_line` (int); `insert_text` (string); `view_range` (array) |

--- a/teramot-documentation/docusaurus.config.ts
+++ b/teramot-documentation/docusaurus.config.ts
@@ -33,7 +33,7 @@ const config: Config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'es'],
   },
 
   markdown: {
@@ -147,6 +147,10 @@ const config: Config = {
         {
           href: 'https://teramot.com',
           label: 'Teramot.com',
+          position: 'right',
+        },
+        {
+          type: 'localeDropdown',
           position: 'right',
         },
 

--- a/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/authentication.md
+++ b/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/authentication.md
@@ -1,0 +1,96 @@
+---
+title: Autenticación
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+
+# Autenticación
+
+El servidor MCP de Teramot admite dos modos de autenticación. Ambos envían un token Bearer al
+servidor; elige el que admita tu cliente.
+
+| Modo | Úsalo para |
+| --- | --- |
+| **OAuth 2.0 + PKCE** | Claude (Code, Desktop, Browser), ChatGPT y cualquier cliente que pueda completar un flujo OAuth |
+| **API key estática** | Cursor, v0.dev, Antigravity y cualquier cliente que solo admita un token Bearer estático |
+
+Ambos modos coexisten en el mismo endpoint y otorgan el mismo acceso. Los métodos de descubrimiento
+`initialize` y `tools/list` no requieren ningún token (ver
+[Introducción → Métodos de arranque](./intro.md#métodos-de-arranque-sin-autenticación)).
+
+<Admonition type="info">
+Tu conexión es **a nivel de cuenta**: las mismas credenciales aplican a todos los workspaces y
+proyectos de tu cuenta Teramot. No necesitas un token distinto por workspace.
+</Admonition>
+
+## OAuth 2.0 + PKCE
+
+Es la opción recomendada para los clientes que la admiten. Solo configuras dos valores —
+la **URL del MCP** (`https://mcp.teramot.com/mcp`) y el **Client ID**
+(`5nldf3wj83yz9f6zbrsjx`). El cliente abre una ventana del navegador, inicias sesión en Teramot
+y el cliente recibe y renueva los tokens automáticamente.
+
+Internamente, el servidor expone los metadatos y endpoints estándar de OAuth 2.0, de modo que la
+mayoría de los clientes MCP se configuran solos sin datos adicionales:
+
+- `GET /.well-known/oauth-authorization-server` — metadatos del servidor de autorización (RFC 8414)
+- `GET /.well-known/oauth-protected-resource` — metadatos del recurso protegido (RFC 9728)
+- `GET /authorize` — endpoint de autorización
+- `POST /token` — endpoint de token
+- `POST /register` — registro dinámico de clientes
+
+El flujo usa PKCE (`S256`) y los scopes `openid email access offline_access`. Consulta
+**[Conectar tu cliente](./connect-clients.md)** para los pasos por cliente.
+
+## API key estática
+
+Para los clientes que no pueden completar el handshake de OAuth (Cursor, v0.dev, Antigravity),
+genera una API key estática y envíala como token Bearer.
+
+### Generar una key
+
+1. Abre la app de Teramot y ve a la página **MCP**.
+2. En la sección **API Keys**, escribe un nombre (p. ej. `cursor-work`) y haz clic en **Generate Key**.
+3. **Copia la key ahora — no se volverá a mostrar.**
+
+Puedes crear varias keys (una por cliente/máquina) y eliminar cualquiera de ellas más tarde desde
+la misma página.
+
+### Usar la key
+
+Envíala en el encabezado `Authorization`:
+
+```http
+Authorization: Bearer YOUR_API_KEY
+```
+
+La mayoría de los clientes MCP aceptan un encabezado personalizado en su configuración de servidor:
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Admonition type="caution">
+Trata las API keys como contraseñas. Otorgan acceso completo a los datos de tu cuenta. Si una key
+se filtra, elimínala desde la página **MCP → API Keys** y genera una nueva.
+</Admonition>
+
+## Errores
+
+| Situación | Resultado |
+| --- | --- |
+| Sin token en un método autenticado | `401 Unauthorized` |
+| Token expirado o inválido | `401 Unauthorized` |
+| Falta `Mcp-Session-Id` en `GET /mcp` | `401 Unauthorized` (`missing Mcp-Session-Id; re-initialize via POST`) |

--- a/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/connect-clients.md
+++ b/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/connect-clients.md
@@ -1,0 +1,144 @@
+---
+title: Conectar tu cliente
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+
+# Conectar tu cliente
+
+Usa estos valores para conectar tu cliente MCP al servidor MCP de Teramot.
+
+| | |
+| --- | --- |
+| **URL del MCP** | `https://mcp.teramot.com/mcp` |
+| **Client ID** | `5nldf3wj83yz9f6zbrsjx` |
+
+<Admonition type="info">
+**Claude** y **ChatGPT** se autentican con OAuth — solo necesitan la URL del MCP (y el Client ID
+si se les solicita). **Cursor**, **v0.dev** y **Antigravity** usan una API key estática — genera una
+primero en la página **MCP → API Keys** (ver [Autenticación](./authentication.md#api-key-estática)).
+</Admonition>
+
+<Tabs>
+
+<TabItem value="claude-code" label="Claude Code">
+
+Ejecuta este comando en tu terminal:
+
+```bash
+claude mcp add --transport http --client-id 5nldf3wj83yz9f6zbrsjx --callback-port 8090 teramot https://mcp.teramot.com/mcp
+```
+
+Se abre una ventana del navegador para que autorices con Teramot. Después, las herramientas
+`teramot` quedan disponibles en Claude Code.
+
+</TabItem>
+
+<TabItem value="claude-desktop" label="Claude Desktop / Browser">
+
+1. Abre **Settings → Developer → MCP Servers** (o **Edit Config**).
+2. Agrega un nuevo servidor con estos valores:
+   - **Name:** `teramot`
+   - **Transport:** `HTTP`
+   - **URL:** `https://mcp.teramot.com/mcp`
+   - **Client ID:** `5nldf3wj83yz9f6zbrsjx` (si es necesario)
+3. Guarda y reinicia Claude Desktop.
+4. Abre un nuevo chat y activa el conector **teramot**.
+
+</TabItem>
+
+<TabItem value="chatgpt" label="ChatGPT">
+
+En ChatGPT, abre **Settings → Apps** (o **Apps & Connectors**), agrega una app MCP personalizada
+y usa estos valores:
+
+- **Server URL:** `https://mcp.teramot.com/mcp`
+- **Client ID:** `5nldf3wj83yz9f6zbrsjx`
+
+Paso a paso en ChatGPT Desktop / Browser:
+
+1. Abre ChatGPT y ve a **Settings**.
+2. Abre **Apps** (o **Apps & Connectors**) y crea/importa una app MCP personalizada.
+3. Configura la app con estos valores:
+   - **Name:** `teramot`
+   - **Transport:** `HTTP`
+   - **URL:** `https://mcp.teramot.com/mcp`
+   - **Client ID:** `5nldf3wj83yz9f6zbrsjx` (si es necesario)
+4. Guarda la configuración y completa la autorización si se solicita.
+5. Abre un nuevo chat y habilita la app **teramot**.
+
+</TabItem>
+
+<TabItem value="cursor" label="Cursor">
+
+Cursor usa una **API key estática**. Primero genera una en la página **MCP → API Keys**
+(ver [Autenticación](./authentication.md#api-key-estática)), luego agrega el servidor a tu
+configuración MCP (Settings → MCP, o `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="v0" label="v0.dev">
+
+v0.dev usa una **API key estática**. Genera una en la página **MCP → API Keys**
+(ver [Autenticación](./authentication.md#api-key-estática)) y agrega el servidor con el
+encabezado `Authorization: Bearer`:
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="antigravity" label="Antigravity">
+
+Antigravity usa una **API key estática**. Genera una en la página **MCP → API Keys**
+(ver [Autenticación](./authentication.md#api-key-estática)) y configura el servidor MCP con el
+encabezado `Authorization: Bearer`:
+
+```json
+{
+  "mcpServers": {
+    "teramot": {
+      "url": "https://mcp.teramot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+## Verificar la conexión
+
+Una vez conectado, pídele a tu cliente que **liste tus workspaces** — debería llamar a
+`list_workspaces` y devolverlos. A partir de ahí puedes explorar proyectos, previsualizar tablas y
+crear tablas de resultados. Consulta la **[Referencia de herramientas](./tools-reference.md)** completa.

--- a/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/intro.md
+++ b/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/intro.md
@@ -1,0 +1,240 @@
+---
+title: Teramot MCP — Introducción
+sidebar_position: 1
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
+
+# Teramot MCP — Introducción
+
+El servidor Model Context Protocol (MCP) de Teramot permite que cualquier cliente de IA
+compatible con MCP (Claude, ChatGPT, Cursor y otros) trabaje directamente con tu plataforma
+de datos Teramot. Una vez conectado, el cliente puede explorar tus workspaces, proyectos y
+fuentes de datos, previsualizar y consultar tablas, y crear nuevas tablas de resultados (gold)
+— todo mediante lenguaje natural.
+
+Implementa el transporte MCP **Streamable HTTP** con OAuth 2.0 (o un token estático) para la
+autenticación.
+
+## Datos esenciales de conexión
+
+| | |
+| --- | --- |
+| **Endpoint** | `https://mcp.teramot.com/mcp` |
+| **Transporte** | Streamable HTTP (`POST` para JSON-RPC, `GET` para el stream SSE) |
+| **Client ID** | `5nldf3wj83yz9f6zbrsjx` |
+| **Autenticación** | OAuth 2.0 + PKCE, o una API key estática (token Bearer) |
+| **Servidor** | `teramot-mcp` `v0.1.0` |
+
+<Admonition type="tip">
+La mayoría de los usuarios no necesita tocar el protocolo directamente — consulta
+**[Conectar tu cliente](./connect-clients.md)** para la configuración lista para copiar y pegar
+de Claude, ChatGPT, Cursor, v0.dev y Antigravity. Esta página documenta el protocolo subyacente
+para integraciones personalizadas.
+</Admonition>
+
+## Cómo funciona la conexión
+
+1. El cliente apunta a `https://mcp.teramot.com/mcp` y (para clientes OAuth) al Client ID anterior.
+2. El cliente llama a `initialize` y `tools/list` para descubrir capacidades — esto **no requiere autenticación**.
+3. Para cualquier trabajo real (`tools/call`), el cliente se autentica con un token Bearer, obtenido
+   mediante el flujo automático de OAuth o una API key estática. Ver **[Autenticación](./authentication.md)**.
+
+## Transporte y endpoints
+
+Todo el tráfico va a un único endpoint: `https://mcp.teramot.com/mcp`.
+
+### `POST /mcp`
+
+Transporta solicitudes JSON-RPC 2.0 (`initialize`, `tools/list`, `tools/call`, …). Las respuestas
+se devuelven como `application/json` o, para operaciones en streaming, como `text/event-stream`.
+
+```http
+POST /mcp HTTP/1.1
+Host: mcp.teramot.com
+Authorization: Bearer YOUR_TOKEN
+Accept: application/json, text/event-stream
+Content-Type: application/json
+Mcp-Session-Id: SESSION_UUID   # devuelto tras initialize
+```
+
+### `GET /mcp`
+
+Abre un stream Server-Sent Events para mensajes del servidor al cliente. Requiere el encabezado
+`Mcp-Session-Id` devuelto por `initialize`; sin él, el servidor responde `401 Unauthorized`
+(`missing Mcp-Session-Id; re-initialize via POST`).
+
+### Métodos de arranque (sin autenticación)
+
+Para permitir que los clientes descubran el servidor antes de autorizar, tres métodos omiten la autenticación:
+
+- `initialize`
+- `tools/list`
+- `notifications/initialized`
+
+Cualquier otro método requiere un token Bearer válido.
+
+## Gestión de sesión
+
+`initialize` devuelve un encabezado de respuesta `Mcp-Session-Id`. Inclúyelo en las solicitudes
+posteriores y en el stream `GET /mcp`. Las sesiones se mantienen en memoria y se reinician cuando
+el servidor se reinicia — si se pierde una sesión, simplemente vuelve a llamar a `initialize`.
+
+## Métodos MCP
+
+### `initialize`
+
+Negocia la versión del protocolo y las capacidades. **No requiere autenticación.**
+
+<Tabs>
+<TabItem value="request" label="Solicitud">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "init-1",
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": { "tools": {} },
+    "clientInfo": { "name": "MyApp", "version": "1.0.0" }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="response" label="Respuesta">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "init-1",
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": { "tools": { "listChanged": true } },
+    "serverInfo": { "name": "teramot-mcp", "version": "v0.1.0" },
+    "instructions": "You are connected to the Teramot data platform. Help users explore their workspaces, projects, data sources, tables, and create results tables."
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+La respuesta incluye el encabezado `Mcp-Session-Id` para las solicitudes posteriores.
+
+### `tools/list`
+
+Lista las herramientas disponibles. **No requiere autenticación** (parte del flujo de arranque).
+Consulta el catálogo completo en **[Referencia de herramientas](./tools-reference.md)**.
+
+<Tabs>
+<TabItem value="request" label="Solicitud">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "list-tools",
+  "method": "tools/list"
+}
+```
+
+</TabItem>
+<TabItem value="response" label="Respuesta">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "list-tools",
+  "result": {
+    "tools": [
+      {
+        "name": "list_workspaces",
+        "description": "Lists all workspaces the user has access to.",
+        "inputSchema": { "type": "object", "properties": {} }
+      },
+      {
+        "name": "preview_table",
+        "description": "Preview the first 100 rows of a data table.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "table_name": { "type": "string", "description": "Name of the table to preview" }
+          },
+          "required": ["table_name"]
+        }
+      }
+    ]
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### `tools/call`
+
+Ejecuta una herramienta. **Requiere autenticación** (token Bearer).
+
+<Tabs>
+<TabItem value="request" label="Solicitud">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "call-tool",
+  "method": "tools/call",
+  "params": {
+    "name": "preview_table",
+    "arguments": { "table_name": "sales" }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="response" label="Respuesta">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "call-tool",
+  "result": {
+    "content": [
+      { "type": "text", "text": "{ \"columns\": [...], \"rows\": [...] }" }
+    ]
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Manejo de errores
+
+Aplican los códigos de error estándar de JSON-RPC 2.0:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-id",
+  "error": { "code": -32602, "message": "Invalid params" }
+}
+```
+
+| Código | Significado |
+| --- | --- |
+| `-32700` | Error de parseo (JSON inválido) |
+| `-32600` | Solicitud inválida (JSON-RPC mal formado) |
+| `-32601` | Método no encontrado |
+| `-32602` | Parámetros inválidos |
+| `-32000` | Error interno / de autenticación |
+
+En la capa HTTP, un token ausente o expirado devuelve `401 Unauthorized`.
+
+## Próximos pasos
+
+- **[Autenticación](./authentication.md)** — OAuth 2.0 y API keys estáticas.
+- **[Conectar tu cliente](./connect-clients.md)** — Claude, ChatGPT, Cursor, v0.dev, Antigravity.
+- **[Referencia de herramientas](./tools-reference.md)** — el catálogo completo de herramientas disponibles.

--- a/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/tools-reference.md
+++ b/teramot-documentation/i18n/es/docusaurus-plugin-content-docs/current/tools-reference.md
@@ -1,0 +1,173 @@
+---
+title: Referencia de herramientas
+sidebar_position: 4
+---
+
+# Referencia de herramientas
+
+El catálogo completo de herramientas expuestas por el servidor MCP de Teramot, agrupadas por dominio.
+Descúbrelas en tiempo de ejecución con `tools/list`; invócalas con `tools/call`
+(ver la [Introducción](./intro.md#métodos-mcp)).
+
+La mayoría de las herramientas aceptan los argumentos opcionales `workspace_name` y `project_name`.
+Si se omiten, el servidor usa tu contexto activo (o el único workspace/proyecto disponible). Si tienes
+varios workspaces, nombra el que quieras usar.
+
+Los nombres de las herramientas y de los parámetros se mantienen en inglés porque son identificadores
+de la API.
+
+## Workspaces
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_workspaces` | Lista todos los workspaces a los que el usuario tiene acceso. Úsala primero para encontrar el nombre del workspace antes de listar proyectos. | — |
+| `create_workspace` | Crea un nuevo workspace — el contenedor de nivel superior que debes crear antes que proyectos o fuentes de datos. | `name` (string, requerido); `index_color` (int); `index_icon` (int) |
+| `update_workspace` | Actualiza el nombre o la apariencia de un workspace existente. | `workspace_name` (string, requerido); `name` (string); `index_color` (int); `index_icon` (int) |
+| `delete_workspace` | Elimina permanentemente un workspace por nombre. Irreversible; requiere acceso de owner. | `workspace_name` (string, requerido) |
+| `get_workspace_owner` | Devuelve el owner (miembro con rol `owner`) de un workspace. | `workspace_name` (string) |
+| `get_workspace_members_idp_subs` | Devuelve los sujetos IDP (`idp_sub`) de todos los miembros del workspace. Útil al configurar usuarios de data egress. | `workspace_name` (string) |
+| `get_workspace_subscription` | Devuelve la suscripción de facturación activa de un workspace, o null para el plan gratuito. | `workspace_name` (string) |
+
+## Proyectos
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_projects` | Lista todos los proyectos, opcionalmente filtrados por workspace. | `workspace_name` (string) |
+| `create_project` | Crea un nuevo proyecto dentro de un workspace. | `workspace_name` (string, requerido); `slug` (string, requerido, 1–28 caracteres URL-safe); `region` (string, requerido); `status` (string, requerido: active \| inactive \| pending) |
+| `update_project` | Actualiza el nombre, slug, región o estado de un proyecto. | `project_name` (string, requerido); `workspace_name` (string); `name` (string); `slug` (string); `region` (string); `status` (string) |
+| `delete_project` | Elimina permanentemente un proyecto por nombre. Irreversible; requiere acceso de owner. | `project_name` (string, requerido); `workspace_name` (string) |
+
+## Fuentes e ingesta
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_sources` | Lista todas las fuentes de datos ETL de un proyecto. | `workspace_name` (string); `project_name` (string) |
+| `create_etl_source` | Crea una fuente de datos ETL conectada a una base de datos o almacenamiento existente. El secret referenciado ya debe existir. | `name` (string, requerido); `secret_name` (string, requerido); `engine` (string, requerido: postgresql \| mysql \| s3 \| bigquery); `slug` (string); `kind` (string); `tables_descriptions` (array); `workspace_name`/`project_name` (string) |
+| `get_etl_source` | Recupera los detalles de una fuente ETL (estado, engine, clave de config, tablas descubiertas). | `source_id` o `source_name` (string); `workspace_name`/`project_name` (string) |
+| `delete_etl_source` | Elimina una fuente ETL permanentemente. El secret asociado no se elimina. | `source_id` o `source_name` (string, uno requerido); `workspace_name`/`project_name` (string) |
+| `discover_schema` | Conecta con la fuente y obtiene sus tablas disponibles. Llamar después de `create_etl_source`. | `source_id` o `source_name` (string); `workspace_name`/`project_name` (string) |
+| `update_etl_source_tables` | Selecciona qué tablas ingerir (y descripciones opcionales). Luego llama a `publish_source` + `wait_for_publish_completion`. | `tables_descriptions` (array, requerido); `source_id`/`source_name` (string); `workspace_name`/`project_name` (string) |
+| `publish_source` | Publica una fuente ETL, disparando el pipeline asíncrono de ingesta/procesamiento. | `source_id` o `source_name` (string); `workspace_name`/`project_name` (string) |
+| `get_etl_source_status` | Estado de ciclo de vida puntual de una fuente ETL (created, disconnected, published, …). | `source_id` o `source_name` (string); `workspace_name`/`project_name` (string) |
+| `test_connection` | Prueba la conexión de una fuente creando una fuente temporal y ejecutando discovery. Limpia en caso de fallo salvo `keep_on_failure`. | `name` (string, requerido); `engine` (string, requerido); campos de conexión (`host`, `port`, `database`, `schema`, `user`, `password`, `path`, `bq_project_id`, `dataset`, `credentials_json`); `keep_on_failure` (bool); `workspace_name`/`project_name` (string) |
+| `wait_for_publish_completion` | Hace polling del pipeline de publicación. Cuando `completed` es false, vuelve a llamar con los `follow_up_arguments` devueltos. | `source_id` o `source_name` (string); `timeout_seconds` (int); `workspace_name`/`project_name` (string) |
+
+## Secrets
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_secrets` | Lista todas las claves de secrets de un proyecto (solo claves y versiones — los valores nunca se devuelven). | `workspace_name` (string); `project_name` (string) |
+| `create_secret` | Crea o actualiza un secret con credenciales de base de datos/S3/BigQuery. Convención: clave `source_<slug>_config`. | `key` (string, requerido); `engine` (string, requerido: postgresql \| mysql \| s3 \| bigquery); campos según engine (`host`, `port`, `database`, `schema`, `user`, `password`, `path`, `bq_project_id`, `dataset`, `credentials_json`); `workspace_name`/`project_name` (string) |
+
+## Archivos y sistema de archivos
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `prepare_file_upload` | Genera URLs S3 PUT prefirmadas para subida directa (`.csv`, `.xls`, `.xlsx`, `.parquet`; hasta 20 archivos; las URLs expiran en 30 min). | `file_names` (array, requerido); `parent_path` (string); `workspace_name`/`project_name` (string) |
+| `create_source_from_upload` | Finaliza un lote de subida registrando los archivos como una fuente ETL de S3. No publica automáticamente. | `uploaded_files` (array de `{name, key, s3_uri}`, requerido); `source_name` (string); `mode` (string: concat \| independent); `workspace_name`/`project_name` (string) |
+| `list_uploaded_files` | Lista los archivos subidos previamente al bucket S3 del proyecto. | `workspace_name` (string); `project_name` (string) |
+| `delete_uploaded_files` | Elimina permanentemente uno o más archivos subidos. No elimina las fuentes ETL que los referencian. | `file_names` (array, requerido); `workspace_name`/`project_name` (string) |
+| `download_uploaded_file` | Construye una URL de descarga autenticada para un archivo subido (requiere el token bearer del solicitante). | `file_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `list_fs_nodes` | Lista el árbol de archivos del proyecto (archivos y carpetas) como jerarquía. | `parent_id` (string); `workspace_name`/`project_name` (string) |
+| `create_folder` | Crea una carpeta en el sistema de archivos del proyecto. | `name` (string, requerido); `parent_path` (string); `workspace_name`/`project_name` (string) |
+| `rename_node` | Renombra un archivo o carpeta (se mantiene bajo el mismo padre — usa `move_node` para reubicar). | `path` (string, requerido); `new_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `rename_uploaded_file` | Alias de `rename_node`, acotado a archivos subidos por el usuario. | `path` (string, requerido); `new_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `move_node` | Mueve un archivo o carpeta bajo un padre distinto. | `path` (string, requerido); `new_parent_path` (string, requerido); `workspace_name`/`project_name` (string) |
+| `move_uploaded_file` | Alias de `move_node`, acotado a archivos subidos por el usuario. | `path` (string, requerido); `new_parent_path` (string, requerido); `workspace_name`/`project_name` (string) |
+| `delete_node` | Elimina un archivo o carpeta (las carpetas eliminan todos sus descendientes). Irreversible. | `path` (string, requerido); `workspace_name`/`project_name` (string) |
+
+## Tablas y datos
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_available_tables` | Lista las tablas del data warehouse. Filtra por `layer`; incluye columnas con `with_columns`. | `with_columns` (bool); `layer` (string: gold \| silver \| bronze); `workspace_name`/`project_name` (string) |
+| `get_sources` | Lista todas las fuentes de datos ETL configuradas para el proyecto actual. | `workspace_name` (string); `project_name` (string) |
+| `preview_table` | Previsualiza las primeras 100 filas de una tabla (columnas, tipos, filas de muestra). Acepta nombre físico o lógico. | `table_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `query_data` | Ejecuta una consulta SQL (dialecto TRINO) contra una tabla; devuelve JSON. Soporta paginación con `execution_id` + `page`. | `table_name` (string, requerido); `sql` (string, requerido salvo que se use `execution_id`); `execution_id` (string); `page` (int); `workspace_name`/`project_name` (string) |
+| `get_sql_definition` | Recupera el `SELECT` SQL detrás de una tabla de resultados (analysis spec). | `table_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `get_table_code` | Devuelve el SQL generado que produce una tabla de origen o procesada. | `table_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `get_artifacts` | Lista las tablas de origen (artifacts) del proyecto, con descripciones y columnas. Primer paso obligatorio antes de `create_gold_table`. | `workspace_name` (string); `project_name` (string) |
+| `profile_table` | Perfila una tabla: total de filas, % de nulos, conteos únicos, valores frecuentes. Opera sobre el proyecto ligado al JWT. | `table_name` (string, requerido) |
+
+## Tablas de resultados (gold)
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `validate_gold_request` | Valida una solicitud de tabla de resultados antes de crearla (nombre, tablas de origen, % de nulos en join keys, …). | `name` (string, requerido); `description` (string); `source_tables` (string); `questions` (string); `join_keys` (string); `workspace_name`/`project_name` (string) |
+| `create_gold_table` | Crea una tabla de resultados (analysis spec); genera SQL a partir de las tablas de origen + questions. Llama a `get_artifacts` primero. | `source_tables` (string, requerido, array JSON de `get_artifacts`); `name` (string); `description` (string); `questions` (string); `knowledges` (string); `workspace_name`/`project_name` (string) |
+| `list_analysis_specs` | Lista todas las tablas de resultados (analysis specs) del proyecto actual. | `workspace_name` (string); `project_name` (string) |
+| `update_gold_table` | Actualiza la descripción de una tabla de resultados (hoy solo la descripción es mutable). | `analysis_spec_name` (string, requerido); `description` (string, requerido); `workspace_name`/`project_name` (string) |
+| `delete_gold_table` | Elimina permanentemente una tabla de resultados y todos sus datos. Dos pasos: llamar con `confirmed=false`, mostrar el mensaje, luego `confirmed=true`. | `analysis_spec_name` (string); `confirmed` (bool); `workspace_name`/`project_name` (string) |
+| `duplicate_gold_table` | Duplica una tabla de resultados en un nuevo analysis spec en borrador. | `analysis_spec_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `regenerate_gold_table_query` | Regenera el SQL de una tabla de resultados (p. ej. tras editar instrucciones o fuentes). | `analysis_spec_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `get_gold_table_lineage` | Devuelve el grafo de linaje de una tabla de resultados por slug (dependencias de origen y análisis derivados). | `slug` (string, requerido); `workspace_name`/`project_name` (string) |
+| `create_gold_table_instructions` | Añade instrucciones de texto libre a una tabla de resultados; dispara una regeneración. | `analysis_spec_name` (string, requerido); `instructions` (array de `{text, id?}`, requerido); `workspace_name`/`project_name` (string) |
+| `update_gold_table_instructions` | Actualiza instrucciones existentes (cada ítem debe incluir su id); dispara una regeneración. | `analysis_spec_name` (string, requerido); `instructions` (array de `{text, id}`, requerido); `workspace_name`/`project_name` (string) |
+| `replace_gold_table_instructions` | Reemplaza el conjunto completo de instrucciones; dispara una regeneración. | `analysis_spec_name` (string, requerido); `instructions` (array de `{text, id?}`, requerido); `workspace_name`/`project_name` (string) |
+| `delete_gold_table_instructions` | Elimina instrucciones específicas por ID; dispara una regeneración. | `analysis_spec_name` (string, requerido); `instruction_ids` (array, requerido); `workspace_name`/`project_name` (string) |
+
+## Estado y monitoreo
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `get_table_status` | Estado detallado de una tabla (gold o silver), incluyendo estado de procesamiento/pipeline. | `table_name` (string, requerido); `include_progress` (bool); `workspace_name`/`project_name` (string) |
+| `get_gold_table_progress` | Eventos de progreso de la creación de una tabla de resultados en curso (o reciente). | `table_name` (string, requerido); `limit` (int); `workspace_name`/`project_name` (string) |
+
+## Refresh y programación
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `refresh_gold_table` | Refresh parcial de una sola tabla de resultados para incorporar nuevos datos de origen (genera una nueva revisión). | `table_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `refresh_all_tables` | Refresh ETL completo de todo el proyecto (genera una nueva revisión de cada tabla). | `workspace_name` (string); `project_name` (string) |
+| `get_refresh_schedule` | Lista los refresh completos de una sola vez programados para un proyecto. | `workspace_name` (string); `project_name` (string) |
+| `schedule_full_refresh_at` | Programa un refresh completo de una sola vez a una hora UTC específica (RFC3339). | `scheduled_at` (string, requerido, RFC3339); `workspace_name`/`project_name` (string) |
+| `delete_refresh_schedule` | Elimina por nombre un refresh completo de una sola vez programado. | `name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `get_cron_refresh_schedule` | Obtiene el refresh recurrente (cron) del proyecto, si existe. | `workspace_name` (string); `project_name` (string) |
+| `set_cron_refresh_schedule` | Crea o actualiza el refresh recurrente. | `frequency` (string, requerido: daily \| weekly \| monthly \| hourly); `time` (string, requerido, HH:MM); `timezone` (string); `interval_hours` (int, requerido para hourly); `enabled` (bool); `workspace_name`/`project_name` (string) |
+| `delete_cron_refresh_schedule` | Elimina el refresh recurrente (cron) (idempotente). | `workspace_name` (string); `project_name` (string) |
+
+## Tareas ETL
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_etl_task_chains` | Lista las cadenas de tareas ETL (pipelines de extremo a extremo) del proyecto. | `status` (string); `usecase_id` (string); `correlation_id` (string); `limit` (int); `cursor` (string); `workspace_name`/`project_name` (string) |
+| `list_etl_tasks` | Lista las tareas ETL (pasos individuales dentro de una cadena). | `chain_id` (string); `status` (string); `task_id` (string); `usecase_id` (string); `correlation_id` (string); `limit` (int); `cursor` (string); `workspace_name`/`project_name` (string) |
+
+## Data egress y compartición
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `get_data_egress_options` | Devuelve las opciones de autenticación de data egress configuradas para un proyecto. Solo lectura. | `workspace_name` (string); `project_name` (string) |
+| `create_egress_user` | Crea/actualiza un usuario en AWS Identity Store y lo asigna a la aplicación Lake Formation del proyecto. | `idp_sub` (string, requerido); `workspace_name`/`project_name` (string) |
+| `grant_table_access` | Otorga a un usuario de Lake Formation acceso de lectura a una o más tablas. | `user_id` (string, requerido); `tables` (array, requerido); `workspace_name`/`project_name` (string) |
+| `revoke_table_access` | Revoca una única tabla de Lake Formation a un usuario. | `user_id` (string, requerido); `table_name` (string, requerido); `workspace_name`/`project_name` (string) |
+| `revoke_database_access` | Revoca todo el acceso a nivel de base de datos en Lake Formation de un usuario (barre todas las tablas). | `user_id` (string, requerido); `workspace_name`/`project_name` (string) |
+| `delete_egress_user` | Elimina un usuario de AWS Identity Store y quita sus permisos de egress. | `user_id` (string, requerido); `workspace_name`/`project_name` (string) |
+| `get_user_tables` | Lista las tablas de Lake Formation a las que un usuario puede acceder (paginado con `next_token`). | `user_id` (string, requerido); `next_token` (string); `workspace_name`/`project_name` (string) |
+| `list_data_shares` | Lista los data shares originados en el proyecto actual. | `workspace_name` (string); `project_name` (string) |
+| `create_data_share` | Comparte datos con otro proyecto (consumidor), opcionalmente con límite de tiempo. | `consumer_project_id` (string, requerido); `shared_resources` (array); `expires_at` (string); `workspace_name`/`project_name` (string) |
+| `update_data_share` | Actualiza un data share (hoy solo `expires_at` es mutable). | `data_share_id` (string, requerido); `expires_at` (string); `clear_expires_at` (bool); `workspace_name`/`project_name` (string) |
+| `delete_data_share` | Elimina permanentemente un data share (el consumidor pierde acceso de inmediato). | `data_share_id` (string, requerido); `workspace_name`/`project_name` (string) |
+
+## Miembros del workspace
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `list_workspace_members` | Lista todos los miembros de un workspace. Requiere rol admin. | `workspace_name` (string, requerido) |
+| `get_workspace_member_role` | Obtiene el rol de un miembro (`owner`, `admin`, `member`, `read-only`). | `workspace_name` (string, requerido); `user_id` (string, requerido) |
+| `add_workspace_member` | Agrega un usuario por email (lo agrega directo si existe, si no lo invita). Requiere rol admin. | `workspace_name` (string, requerido); `email` (string, requerido) |
+| `update_workspace_member_role` | Actualiza el rol de un miembro. Requiere rol admin. | `workspace_name` (string, requerido); `user_id` (string, requerido); `role` (string, requerido) |
+| `remove_workspace_member` | Quita un miembro de un workspace. Requiere rol admin. | `workspace_name` (string, requerido); `user_id` (string, requerido) |
+| `list_workspace_invitations` | Lista las invitaciones pendientes de un workspace. Requiere rol admin. | `workspace_name` (string, requerido) |
+
+## Chat
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `chat` | Envía un mensaje de chat; la IA entiende la intención y consulta workspaces, proyectos, fuentes y tablas. El alcance de la conversación es inmutable una vez fijado. | `message` (string, requerido); `conversation_id` (string); `workspace_id` (string); `project_id` (string) |
+
+## Memoria
+
+| Herramienta | Descripción | Parámetros |
+| --- | --- | --- |
+| `memory` | Gestiona archivos de memoria persistente del agente (view, create, str_replace, insert, delete, rename). | `command` (string, requerido: view \| create \| str_replace \| insert \| delete \| rename); `path` (string); `old_path` (string); `new_path` (string); `file_text` (string); `old_str` (string); `new_str` (string); `insert_line` (int); `insert_text` (string); `view_range` (array) |


### PR DESCRIPTION
- Created authentication.md for authentication methods (OAuth 2.0 + PKCE and static API key).
- Created connect-clients.md detailing how to connect various clients (Claude, ChatGPT, Cursor, v0.dev, Antigravity) to the MCP server.
- Created intro.md providing an overview of the Teramot MCP, connection essentials, and how it works.
- Created tools-reference.md listing all available tools in the MCP server, organized by domain.